### PR TITLE
Add an option to even leaves

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,8 @@ func main() {
 	}
 	tree := Tree{
 		Leaves: leaves,
+		// In case that we need even leaves
+		MustBalance: true
 	}
 
 	tree.BuildTree()

--- a/tree.go
+++ b/tree.go
@@ -10,13 +10,29 @@ import (
 
 // Tree a merkle tree structure
 type Tree struct {
-	Root   *Node   `json:"root"`
-	Leaves []*Node `json:"leaves"`
+	Root        *Node   `json:"root"`
+	Leaves      []*Node `json:"leaves"`
+	MustBalance bool    `json:"MustBalance"`
 }
 
 // BuildTree build a tree out of Leaves
 func (t *Tree) BuildTree() error {
+	if t.MustBalance {
+		t.Leaves = t.fixOdd(t.Leaves)
+	}
+
 	return t.buildTree(t.Leaves)
+}
+
+// fixOdd will duplicate the last odd leave to make the tree contains even leaves
+func (t *Tree) fixOdd(leaves []*Node) []*Node {
+	leavesCount := len(leaves)
+	if leavesCount%2 == 0 {
+		return leaves
+	}
+
+	lastLeave := leaves[leavesCount-1]
+	return append(leaves, lastLeave)
 }
 
 // buildTree build a tree out of a slice of leaves
@@ -80,7 +96,6 @@ func (t *Tree) VerifyAudit(rootHash []byte, targetHash []byte, auditTrail []*Pro
 		} else {
 			testHash = computeHash(append(proof.Hash, testHash...))
 		}
-
 	}
 
 	return reflect.DeepEqual(rootHash, testHash)

--- a/tree_test.go
+++ b/tree_test.go
@@ -63,6 +63,26 @@ func TestBuildTreeOddNode(t *testing.T) {
 	assert.Equal(t, 3, len(tree.Leaves))
 }
 
+func TestBuildTreeMustBalance(t *testing.T) {
+	leaves := []*Node{
+		NewNode([]byte("1")),
+		NewNode([]byte("2")),
+		NewNode([]byte("3")),
+	}
+	tree := Tree{
+		Leaves:      leaves,
+		MustBalance: true,
+	}
+
+	leftRootHash := computeHash(append(leaves[0].Hash, leaves[1].Hash...))
+	rightRootHash := computeHash(append(leaves[2].Hash, leaves[2].Hash...))
+	rootHash := computeHash(append(leftRootHash, rightRootHash...))
+
+	assert.NoError(t, tree.BuildTree())
+	assert.Equal(t, tree.Root.Hash, rootHash)
+	assert.Equal(t, 4, len(tree.Leaves))
+}
+
 func TestAppendLeaf(t *testing.T) {
 	tree := Tree{}
 	tree.AppendLeaf(NewNode([]byte("1")))


### PR DESCRIPTION
Add `MustBalance` option to `Tree` to allow for the case when a tree need even leaves.
This will duplicate the last odd leave as its pair to make the leaves even.